### PR TITLE
Escape slashes in folder and file names

### DIFF
--- a/tidysic/algorithms.py
+++ b/tidysic/algorithms.py
@@ -127,33 +127,22 @@ def parse_in_directory(audio_files, with_album, guess, verbose):
 
 def move_files(artists, dir_target, with_album, dry_run=False):
     for artist, second_level in artists.items():
-        # Directory name of the file based on the target directory and the
-        # artist
-        artist_dir_name = os.path.join(dir_target, artist)
-
-        create_dir(artist_dir_name, dry_run)
+        # Directory name of the file based on the
+        # target directory and the artist
+        artist_dir = create_dir(artist, dir_target, dry_run)
 
         if with_album:
             for album, titles in second_level.items():
-                # Subdirectory for the album
-                album_dir_name = os.path.join(artist_dir_name, album)
-                create_dir(album_dir_name, dry_run)
+                # Create album folder
+                album_dir = create_dir(album, artist_dir, dry_run)
 
                 for title, file in titles.items():
-                    # Rename the file
-                    f_name = title + file_extension(file)
-                    f_target_path = os.path.join(album_dir_name, f_name)
-
                     # Moves the file to its new path
-                    move_file(file, f_target_path, dry_run)
+                    move_file(file, title, album_dir, dry_run)
         else:
             for title, file in second_level.items():
-                # Rename the file
-                f_name = title + file_extension(file)
-                f_target_path = os.path.join(artist_dir_name, f_name)
-
                 # Moves the file to its new path
-                move_file(file, f_target_path, dry_run)
+                move_file(file, title, artist_dir, dry_run)
 
 
 def clean_up(dir_src, audio_files, dry_run=False):

--- a/tidysic/algorithms.py
+++ b/tidysic/algorithms.py
@@ -2,7 +2,7 @@ from tinytag import TinyTag
 import eyed3
 import os
 
-from .os_utils import (file_extension, filename,
+from .os_utils import (filename,
                        create_dir, get_audio_files, move_file,
                        remove_directory)
 from .logger import log, error, warning

--- a/tidysic/os_utils.py
+++ b/tidysic/os_utils.py
@@ -33,14 +33,19 @@ def file_extension(path):
     return os.path.splitext(path)[1]
 
 
-def create_dir(dir_path, dry_run):
+def create_dir(dir_name, parent_path, dry_run):
     '''
-    Creates the given directory if it does not exist yet.
+    Creates a directory with the given name
+    in the given parent directory
     '''
+    dir_name = dir_name.replace('/', '-')
+    full_path = os.path.join(parent_path, dir_name)
     if dry_run:
-        logger.dry_run(f'Create directory {dir_path}')
-    elif not os.path.exists(dir_path):
-        os.makedirs(dir_path)
+        logger.dry_run(f'Create directory {full_path}')
+    elif not os.path.exists(full_path):
+        os.makedirs(full_path)
+
+    return full_path
 
 
 def get_audio_files(directory_path):
@@ -55,15 +60,17 @@ def get_audio_files(directory_path):
     return audio_files
 
 
-def move_file(file, target_path, dry_run=False):
+def move_file(file, target_name, target_path, dry_run=False):
     '''
     Moves the given file onto the given path
     '''
+    target_name = target_name.replace('/', '-')
+    full_path = os.path.join(target_path, target_name)
     if dry_run:
         # We don't display the two whole paths
         # Only the source's filename and the target directory
         src = file.split('/')[-1]
-        target = '/'.join(target_path.split('/')[:-1])
+        target = '/'.join(full_path.split('/')[:-1])
 
         logger.dry_run([
             'Moving file',
@@ -72,7 +79,7 @@ def move_file(file, target_path, dry_run=False):
             target
         ])
     else:
-        shutil.move(file, target_path)
+        shutil.move(file, full_path)
 
 
 def remove_directory(dir_path, dry_run=False):

--- a/tidysic/os_utils.py
+++ b/tidysic/os_utils.py
@@ -65,6 +65,8 @@ def move_file(file, target_name, target_path, dry_run=False):
     Moves the given file onto the given path
     '''
     target_name = target_name.replace('/', '-')
+    target_name += file_extension(file)
+    
     full_path = os.path.join(target_path, target_name)
     if dry_run:
         # We don't display the two whole paths


### PR DESCRIPTION
Close #46 

This will prevent tidysic from attempting to create directories of files whose names conflict with UNIX file systems.

Note that this doesn't fix anything for Windows.