### PR TITLE
Quick fix

### DIFF
--- a/tidysic/audio_file.py
+++ b/tidysic/audio_file.py
@@ -79,7 +79,7 @@ class AudioFile(object):
                 if answer == 'r':
                     new_tags[Tag.Title] = input('Title : ')
                     new_tags[Tag.Artist] = input('Artist : ')
-                    
+
                     self.save_tags(dry_run)
 
         except BaseException:
@@ -116,11 +116,25 @@ class AudioFile(object):
         Creates the new file's name from the tags in the desired format
         '''
         from .os_utils import file_extension  # Avoid circular import
+
+        title = self.tags[Tag.Title]
+        album = self.tags[Tag.Album]
+        artist = self.tags[Tag.Artist]
+        year = self.tags[Tag.Year]
+        track = self.tags[Tag.Track]
+        genre = self.tags[Tag.Genre]
+
+        if year:
+            year = int(year)
+
+        if track:
+            track = int(track)
+
         return format.format(
-            title=self.tags[Tag.Title],
-            album=self.tags[Tag.Album],
-            artist=self.tags[Tag.Artist],
-            year=self.tags[Tag.Year],
-            track=int(self.tags[Tag.Track]),
-            genre=self.tags[Tag.Genre]
+            title=title,
+            album=album,
+            artist=artist,
+            year=year,
+            track=track,
+            genre=genre
         ) + file_extension(self.file)

--- a/tidysic/os_utils.py
+++ b/tidysic/os_utils.py
@@ -54,7 +54,7 @@ def get_audio_files(directory_path):
     Returns the audio files present in the given directory.
     '''
     audio_files = [
-        AudioFile(os.path.join(directory_path, path))
+        AudioFile(path)
         for ext in audio_extensions
         for path in Path(directory_path).rglob('*'+ext)
     ]
@@ -70,7 +70,7 @@ def move_file(file, target_name, target_path, dry_run=False):
     if dry_run:
         # We don't display the two whole paths
         # Only the source's filename and the target directory
-        src = file.split('/')[-1]
+        src = file.name
 
         logger.dry_run([
             'Moving file',


### PR DESCRIPTION
This PR fixes 2 small bugs in `os_utils` that were caused by the recent switch from `str` to `AudioFile` in some methods.

It also adds a small check for tags `Year` and `Track` so that it may convert them to `int` for more advanced formatting.